### PR TITLE
fix : 파일확장자를 jpg, jpeg, png, gif, webp 파일만 업로드 할 수 있도록 수정

### DIFF
--- a/src/views/create/WorldcupCreate.vue
+++ b/src/views/create/WorldcupCreate.vue
@@ -88,6 +88,7 @@
             
             <el-upload
               action="http://localhost:3000/upload"
+              accept=".jpg,.jpeg,.png,.gif,.webp"
               name="image"
               :headers="uploadHeaders"
               :show-file-list="false"
@@ -203,18 +204,29 @@ function removeCandidate(index) {
 }
 
 function beforeUpload(file) {
-  const isImage = file.type.startsWith('image/')
-  const isLt5M = file.size / 1024 / 1024 < 5
+  // 1. 허용할 확장자 목록
+  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 
-  if (!isImage) {
-    ElMessage.error('이미지 파일만 업로드 가능합니다!')
-    return false
+  // 2. 파일 타입 확인
+  const isImage = allowedTypes.includes(file.type);
+
+  // 3. (옵션) 확장자 명으로 한 번 더 확인
+  const extension = file.name.substring(file.name.lastIndexOf('.') + 1).toLowerCase();
+  const isExtAllowed = ['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(extension);
+
+  if (!isImage && !isExtAllowed) {
+    ElMessage.error('JPG, PNG, GIF, WebP 형식의 이미지인지만 확인해주세요!');
+    return false;
   }
+
+  // 용량 제한도 추가하는 것을 권장합니다 (예: 5MB)
+  const isLt5M = file.size / 1024 / 1024 < 5;
   if (!isLt5M) {
-    ElMessage.error('이미지 크기는 5MB를 초과할 수 없습니다!')
-    return false
+    ElMessage.error('이미지 크기는 5MB를 넘을 수 없습니다.');
+    return false;
   }
-  return true
+
+  return true;
 }
 
 function handleCandidateImageUpload(response, index) {


### PR DESCRIPTION
<img width="1087" height="595" alt="image" src="https://github.com/user-attachments/assets/1170330a-0c15-4328-af23-59addca31aca" />

upload 전 실행되는 beforeUpload에서
- 확장자를 jpeg, png, gif, webp로 제한
- 파일 타입 확인
- 확장자 명으로 한번 더 확인
- 용량 제한을 5MB로 제한
위의 4가지 조건을 검사하는 로직으로 변경