### PR TITLE
Chore : 폰트 컬러 변경

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -12,9 +12,9 @@
   --purple-light: #E5D9FF;
   --purple-dark: #C09FFF;
 
-  --gradient-pink: linear-gradient(135deg, #FFB3D9 0%, #FFC9E5 100%);
+  --gradient-pink: linear-gradient(135deg, #e572ac 0%, #a373f7 100%);
   --gradient-purple: linear-gradient(135deg, #D4BBFF 0%, #E5D9FF 100%);
-  --gradient-mix: linear-gradient(135deg, #FFB3D9 0%, #D4BBFF 100%);
+  --gradient-mix: linear-gradient(135deg, #e572ac 0%, #a373f7 100%);
 
   /* 배경 - 깔끔한 흰색 베이스 */
   --bg-primary: #FFFFFF;


### PR DESCRIPTION
<img width="234" height="62" alt="스크린샷 2026-02-04 오전 11 25 46" src="https://github.com/user-attachments/assets/13fe9ee2-b7f7-4ba3-bc01-26476f8059f5" />

<img width="752" height="97" alt="스크린샷 2026-02-04 오전 11 25 58" src="https://github.com/user-attachments/assets/2fa73cbe-cd62-454c-96c7-0f86dc259791" />

기존 폰트 컬러가 월드컵, 퀴즈 선택 창에서 글씨가 안보여 컬러 변경 업데이트 진행했습니다.